### PR TITLE
Component breaks if it doesn't receive props.value

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,7 @@ export default class HighlightedTextarea extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      input: props.value,
+      input: props.value ? props.value : '',
     };
     this._handleInputChange = this._handleInputChange.bind(this);
     this._handleScroll = this._handleScroll.bind(this);


### PR DESCRIPTION
props.value -> this.state.input, then .replace() is called on this.state.input (which is undefined if props.value isn't passed)